### PR TITLE
Add snap install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,23 @@ SQLite3 libraries are included.
 
 These notes assume that you are already familiar with Pharo.  If not, please visit the website at http://pharo.org/
 
+## Installing Pharo
 
-## Compatibility
+Install Pharo in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
 
-Pharo image 60442 or later is required for Cairo support.
+    snap install pharo --classic --edge
+
+Installing a snap is very quick. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
 
 Opening URL's in a browser on the host requires snapd-xdg-open to be installed on the host.  On Ubuntu based systems:
 
 ```bash
 $ sudo apt-get install snapd-xdg-open
 ```
+
+## Compatibility
+
+Pharo image 60442 or later is required for Cairo support.
 
 
 ## Building the package


### PR DESCRIPTION
Thanks for publishing Pharo in the snap store! You've made quite a complex install process very simple :-)

This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install pharo --edge- --classic` simplifying the installation instructions for your users.

Once the snap is released into the stable channel in the store, users no longer need to add the `--edge` and Pharo will appear in the desktop Software Center.